### PR TITLE
Remove Windows-specific Java home path from workspace .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,7 +26,6 @@
     },
   ],
   "java.test.defaultConfig": "WPIlibUnitTests",
-  "java.jdt.ls.java.home": "C:\\Users\\Public\\wpilib\\2025\\jdk",
   "java.format.settings.url": ".vscode/java-formatter.xml",
   "java.import.gradle.annotationProcessing.enabled": false,
   "java.completion.favoriteStaticMembers": [


### PR DESCRIPTION
This path points VS Code to the Windows WPILib installation location, and may cause issues on MacOS or Linux. Since WPILib VS Code configures this setting properly on a per-OS basis in user settings, it's unneccessary to set in the workspace settings.